### PR TITLE
Fix bug - Adjacent words not separated by space

### DIFF
--- a/folioreader/src/main/java/com/folioreader/ui/base/HtmlTask.java
+++ b/folioreader/src/main/java/com/folioreader/ui/base/HtmlTask.java
@@ -40,8 +40,10 @@ public class HtmlTask extends AsyncTask<String, Void, String> {
             StringBuilder stringBuilder = new StringBuilder();
             String line;
             while ((line = bufferedReader.readLine()) != null) {
-                stringBuilder.append(line);
+                stringBuilder.append(line).append('\n');
             }
+            if (stringBuilder.length() > 0)
+                stringBuilder.deleteCharAt(stringBuilder.length() - 1);
             return stringBuilder.toString();
         } catch (IOException e) {
             Log.e(TAG, "HtmlTask failed", e);


### PR DESCRIPTION
Html contents were not being fetched exactly as the source file.
This bug was visible when <body> tag had '\n' characters.

Test File - TheSilverChair.epub
Chapter I - Behind the Gym
Search 'fifteen' of second paragraph in commit prior to this.